### PR TITLE
feat(layouts): add open graph meta tags support

### DIFF
--- a/src/components/astro/OpenGraph.astro
+++ b/src/components/astro/OpenGraph.astro
@@ -1,0 +1,33 @@
+---
+export type Props = {
+  /** Description of the page */
+  description: string;
+  /** Title of the page */
+  title: string;
+  /** URL of the page */
+  url: string;
+  /** Optional image URL for the page */
+  image?: string;
+  imgWidth?: string;
+  imgHeight?: string;
+  /** Optional type of the page, either "website" or "article" */
+  type?: "website" | "article" | "book" | "profile";
+  /** Twitter username */
+  twitterUsername?: string;
+};
+const { description, title, url, image, type, twitterUsername, imgHeight, imgWidth } = Astro.props;
+---
+
+<meta property="og:title" content={title} />
+<meta property="og:type" content={type || "website"} />
+<meta property="og:image" content={image} />
+<meta property="og:url" content={url} />
+<meta property="og:description" content={description} />
+<!-- Twitter -->
+<meta property="og:image:width" content={imgWidth || "1280"} />
+<meta property="og:image:height" content={imgHeight || "640"} />
+<meta property="twitter:card" content="summary_large_image" />
+<meta property="twitter:image" content={image} />
+<meta property="twitter:site" content={twitterUsername} />
+
+ 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -9,6 +9,7 @@ import Toc from "#components/astro/Toc.astro";
 import { SITE_DESCRIPTION, SITE_TITLE } from "#utils/site-config";
 import "@fpkit/acss/styles";
 import "../styles/index.css";
+import OpenGraph from "#components/astro/OpenGraph.astro";
 
 // types
 type routeItem = {
@@ -23,12 +24,16 @@ type Props = {
   showBreadcrumb?: boolean;
   markdownHeaders?: string[];
   breadcrumbRoutes?: routeItem[];
+  ogImage?: string;
+  ogDescription?: string;
 };
+
+const currentPageSlug = Astro.url.pathname;
 
 const showBreadcrumb =
   Astro.props.showBreadcrumb === undefined ? true : Astro.props.showBreadcrumb;
 
-const { pageTitle, pageDescription, breadcrumbRoutes, pageImageUrl, markdownHeaders } =
+const { pageTitle, pageDescription, breadcrumbRoutes, pageImageUrl, markdownHeaders, ogImage, ogDescription } =
   Astro.props;
 ---
 
@@ -42,6 +47,14 @@ const { pageTitle, pageDescription, breadcrumbRoutes, pageImageUrl, markdownHead
     <meta name="viewport" content="width=device-width" />
     <meta name="generator" content={Astro.generator} />
     <title>{pageTitle || SITE_TITLE}</title>
+    <OpenGraph
+    title={pageTitle || SITE_TITLE}
+    description={ogDescription || pageDescription || SITE_DESCRIPTION}
+    url={Astro.url.href}
+    image={ogImage || "/images/a11y-banner.webp"}
+    type="article"
+    twitterUsername="shawnsandy"
+  />
     <ViewTransitions />
   </head>
   <body>

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -1,9 +1,6 @@
 ---
 import Layout from "./Layout.astro";
 import Youtube from "#components/astro/Youtube.astro";
-import Img from "#components/astro/Img.astro";
-import Toc from "#components/astro/Toc.astro";
-import TextToSpeech from "#components/astro/TextToSpeech.astro";
 import type { TODO } from "#utils/types.js";
 const frontmatter = Astro.props.frontmatter;
 const headings = Astro.props.headings;
@@ -29,6 +26,8 @@ const contentRoute: ContentRoute[] = [
   pageDescription={frontmatter.description}
   breadcrumbRoutes={contentRoute}
   markdownHeaders={headings}
+  ogImage={frontmatter.image?.url || null}
+  ogDescription={frontmatter.summary || frontmatter.description}
 >
   {
     frontmatter.image && (


### PR DESCRIPTION
* integrate opengraph component into main layout for improved social sharing
* add support for custom og image and description in markdown posts
* set default og image to a11y-banner.webp when no custom image provided
* enable twitter card integration with username
* pass frontmatter image and summary as og meta properties